### PR TITLE
Removed Python2.7 mentions from docs, travis and tox  conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ sudo: false
 matrix:
     fast_finish: true
     include:
-      - { python: "2.7", env: DJANGO=1.11 }
-
       - { python: "3.4", env: DJANGO=1.11 }
       - { python: "3.4", env: DJANGO=2.0 }
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Requirements
 
 Supported versions
 *******************
-* Python 2.7, 3.4, 3.5, 3.6, 3.7
+* Python 3.4, 3.5, 3.6, 3.7
 * Django 1.11, 2.0, 2.1
 * Django REST Framework 3.8
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -16,7 +16,7 @@ Requirements
 
 Supported versions
 *******************
-* Python 2.7, 3.4, 3.5, 3.6, 3.7
+* Python 3.4, 3.5, 3.6, 3.7
 * Django 1.11, 2.0, 2.1
 * Django REST Framework 3.8
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ omit =
 usedevelop = true
 passenv = HOME CI TRAVIS TRAVIS_*
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -39,7 +38,6 @@ deps =
     django20: django>=2.0,<2.1
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
-    py27: mock
     -r{toxinidir}/testproject/requirements/common.txt
 setenv =
     PYTHONPATH = {toxinidir}/testproject


### PR DESCRIPTION
Python2.7 is not supported so it should not be mentioned neither in docs nor in Travis/Tox conf.