### PR TITLE
Fixed otp code validation

### DIFF
--- a/trench/serializers.py
+++ b/trench/serializers.py
@@ -120,12 +120,13 @@ class ProtectedActionSerializer(serializers.Serializer):
     )
 
     default_error_messages = {
+        'otp_code_missing': _('OTP code not provided.'),
         'code_invalid_or_expired': _('Code invalid or expired.'),
     }
 
-    def validate_code(self, value):
-        if not self.requires_mfa_code:
-            return value  # pragma: no cover
+    def _validate_code(self, value):
+        if not value:
+            self.fail('otp_code_missing')
 
         obj = self.context['obj']
         validity_period = (
@@ -140,6 +141,12 @@ class ProtectedActionSerializer(serializers.Serializer):
             return value
 
         self.fail('code_invalid_or_expired')
+
+    def validate(self, data):
+        if self.requires_mfa_code:
+            self._validate_code(data.get('code'))
+
+        return super().validate(data)
 
 
 class RequestMFAMethodActivationConfirmSerializer(ProtectedActionSerializer):


### PR DESCRIPTION
Hey!

As stated in official DRF [docs](https://www.django-rest-framework.org/api-guide/serializers/) validation is not run for field declared with required=False.

> Note: If your <field_name> is declared on your serializer with the parameter required=False then this validation step will not take place if the field is not included.

That means that `validate_code()` in class ProtectedActionSerializer would never be exectued, and actions that should require OTP code would pass without without including it.