### PR TITLE
Fixed running tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,13 @@
+CHANGELOG
 =========
-Changelog
-=========
 
-All notable changes to this project will be documented in this file.
+0.1.1 (unreleased)
+------------------
 
-Released
-""""""""
+* Fixed problem with running tests
 
-`0.1.0` (08-11-2018)
-********************
 
-Stable init version.
+0.1.0 (2018-11-08)
+------------------
+
+* Stable init version


### PR DESCRIPTION
PR resolves problem with running tests:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/_pytest/config/__init__.py", line 409, in _importconftest
    mod = conftestpath.pyimport()
  File "/usr/local/lib/python3.6/site-packages/py/_path/local.py", line 668, in pyimport
    __import__(modname)
ModuleNotFoundError: No module named 'code.tests'; 'code' is not a package
ERROR: could not load /code/tests/conftest.py
```