### PR TITLE
Add code validation to tests after OTP validation fix merged

### DIFF
--- a/testproject/tests/test_second_step_authentication.py
+++ b/testproject/tests/test_second_step_authentication.py
@@ -212,8 +212,7 @@ def test_activation_otp_confirm_wrong(active_user):
     )
     assert response.status_code == 400
     error_code = 'code_invalid_or_expired'
-    assert error_code == response.data.get('code')[0].code
-
+    assert response.data.get('non_field_errors')[0].code == error_code
 
 @pytest.mark.django_db
 def test_confirm_activation_otp(active_user):
@@ -266,6 +265,9 @@ def test_deactivation_otp(active_user_with_email_otp):
     )
     response = client.post(
         path='/auth/email/deactivate/',
+        data={
+            'code': create_otp_code(secret),
+        },
         format='json',
     )
     assert response.status_code == 204
@@ -320,7 +322,10 @@ def test_new_method_after_deactivation(active_user_with_many_otp_methods):
     )
     response = client.post(
         path='/auth/email/deactivate/',
-        data={'new_primary_method': 'sms'},
+        data={
+            'code': create_otp_code(first_primary_method.secret),
+            'new_primary_method': 'sms',
+        },
         format='json',
     )
     new_primary_method = active_user_with_many_otp_methods.mfa_methods.filter(
@@ -711,6 +716,9 @@ def test_backup_codes_regeneration(active_user_with_backup_codes):
     )
     response = client.post(
         path='/auth/email/codes/regenerate/',
+        data={
+            'code': create_otp_code(first_primary_method.secret),
+        },
         format='json',
     )
     new_backup_codes = \


### PR DESCRIPTION
As found out by @sleeske in #17, code validation has been actually skipped due to 'required' parameter set to False. After that fix, tests needed to be tweaked accordingly.