### PR TITLE
Install only `trench` module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from trench import __version__
 setup(
     name='django-trench',
     version=__version__,
-    packages=find_packages(),
+    packages=find_packages(include=['trench', 'trench.*']),
     include_package_data=True,
     license='MIT License',
     description='REST Multi-factor authentication package for Django',


### PR DESCRIPTION
- skip installation of testproject