### PR TITLE
Replace split method on ephemeral_token with rsplit

### DIFF
--- a/trench/utils.py
+++ b/trench/utils.py
@@ -44,7 +44,7 @@ class UserTokenGenerator(PasswordResetTokenGenerator):
 
         try:
             token = str(token)
-            user_pk, ts_b36, hash = token.split('-')
+            user_pk, ts_b36, hash = token.rsplit('-', 2)
             ts = base36_to_int(ts_b36)
             user = User._default_manager.get(pk=user_pk)
         except (ValueError, TypeError, User.DoesNotExist):


### PR DESCRIPTION
Replace split method on ephemeral_token with rsplit to handle scenario when UUID or value other than integer is used for User's PK and ensure token is split properly.
Solves the issue #34 

Solution suggested by @chaosk 