### PR TITLE
Change url patterns and exception handling for method activation views

### DIFF
--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -3,6 +3,7 @@ django-environ==0.4.5
 django-cors-headers==2.4.0
 djoser==1.2.1
 djangorestframework_simplejwt==3.3.0
+django-rest-swagger==2.1.2
 
 pytest==4.1.0
 pytest-cov==2.6.1

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'djoser',
     'corsheaders',
+    'rest_framework_swagger',
 
     'testapp',
     'trench',

--- a/testproject/testapp/urls.py
+++ b/testproject/testapp/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from rest_framework_swagger.views import get_swagger_view
+
+schema_view = get_swagger_view(title='Django-Trench')
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
@@ -23,4 +26,5 @@ urlpatterns = [
     url(r'^auth/', include('trench.urls.jwt')),
     url(r'^simplejwt-auth/', include('trench.urls.simplejwt')),
     url(r'^djoser/', include('djoser.urls')),
+    url(r'^swagger/', schema_view)
 ]

--- a/trench/backends/__init__.py
+++ b/trench/backends/__init__.py
@@ -1,8 +1,5 @@
-from trench.utils import (
-    get_nested_attr_value,
-    create_otp_code,
-)
 from trench.exceptions import MissingSourceFieldAttribute
+from trench.utils import create_otp_code, get_nested_attr_value
 
 
 class AbstractMessageDispatcher:

--- a/trench/urls/base.py
+++ b/trench/urls/base.py
@@ -1,30 +1,33 @@
 from django.conf.urls import url
 
 from trench import views
+from trench.settings import api_settings
 
 
 __all__ = [
     'urlpatterns',
 ]
 
+mfa_methods_choices = '|'.join(api_settings.MFA_METHODS.keys())
+
 urlpatterns = [
     url(
-        r'^(?P<method>[-\w]+)/activate/$',
+        r'^(?P<method>({}))/activate/$'.format(mfa_methods_choices),
         views.RequestMFAMethodActivationView.as_view(),
         name='mfa-activate',
     ),
     url(
-        r'^(?P<method>[-\w]+)/activate/confirm/$',
+        r'^(?P<method>({}))/activate/confirm/$'.format(mfa_methods_choices),
         views.RequestMFAMethodActivationConfirmView.as_view(),
         name='mfa-activate-confirm',
     ),
     url(
-        r'^(?P<method>[-\w]+)/deactivate/$',
+        r'^(?P<method>({}))/deactivate/$'.format(mfa_methods_choices),
         views.RequestMFAMethodDeactivationView.as_view(),
         name='mfa-deactivate',
     ),
     url(
-        r'^(?P<method>[-\w]+)/codes/regenerate/$',
+        r'^(?P<method>({}))/codes/regenerate/$'.format(mfa_methods_choices),
         views.RequestMFAMethodBackupCodesRegenerationView.as_view(),
         name='mfa-regenerate-codes',
     ),

--- a/trench/views/base.py
+++ b/trench/views/base.py
@@ -1,21 +1,12 @@
 from django.contrib.auth.hashers import make_password
-from django.db import (
-    IntegrityError,
-    transaction,
-)
+from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import status
 from rest_framework.exceptions import NotFound
-from rest_framework.generics import (
-    CreateAPIView,
-    GenericAPIView,
-)
-from rest_framework.permissions import (
-    AllowAny,
-    IsAuthenticated,
-)
+from rest_framework.generics import CreateAPIView, GenericAPIView
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/trench/views/base.py
+++ b/trench/views/base.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import status
+from rest_framework.exceptions import NotFound
 from rest_framework.generics import (
     CreateAPIView,
     GenericAPIView,
@@ -110,7 +111,12 @@ class RequestMFAMethodActivationView(GenericAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context['name'] = self.kwargs.get('method')
+
+        try:
+            context['name'] = self.kwargs['method']
+        except KeyError:
+            raise NotFound()
+
         return context
 
     def post(self, request, *args, **kwargs):
@@ -143,11 +149,16 @@ class RequestMFAMethodActivationConfirmView(GenericAPIView):
     def get_serializer_context(self):
         context = super().get_serializer_context()
         obj = getattr(self, 'obj', None)
-        context.update({
-            'name': self.kwargs['method'],
-            'obj': obj,
-            'conf': api_settings.MFA_METHODS[self.kwargs['method']],
-        })
+
+        try:
+            context.update({
+                'name': self.kwargs['method'],
+                'obj': obj,
+                'conf': api_settings.MFA_METHODS[self.kwargs['method']],
+            })
+        except KeyError:
+            raise NotFound()
+
         return context
 
     def post(self, request, *args, **kwargs):
@@ -187,11 +198,16 @@ class RequestMFAMethodDeactivationView(GenericAPIView):
     def get_serializer_context(self):
         context = super().get_serializer_context()
         obj = getattr(self, 'obj', None)
-        context.update({
-            'name': self.kwargs['method'],
-            'obj': obj,
-            'conf': api_settings.MFA_METHODS[self.kwargs['method']],
-        })
+
+        try:
+            context.update({
+                'name': self.kwargs['method'],
+                'obj': obj,
+                'conf': api_settings.MFA_METHODS[self.kwargs['method']],
+            })
+        except KeyError:
+            raise NotFound()
+
         return context
 
     def post(self, request, *args, **kwargs):
@@ -245,11 +261,16 @@ class RequestMFAMethodBackupCodesRegenerationView(GenericAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context.update({
-            'name': self.kwargs['method'],
-            'obj': self.obj,
-            'conf': api_settings.MFA_METHODS[self.kwargs['method']],
-        })
+
+        try:
+            context.update({
+                'name': self.kwargs['method'],
+                'obj': self.obj,
+                'conf': api_settings.MFA_METHODS[self.kwargs['method']],
+            })
+        except KeyError:
+            raise NotFound()
+
         return context
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Solves an issue when Swagger is used. Swagger's schemes inspectors inject None value to url params, what caused several errors. Url patterns are extended to accept specific choices of configured MFA METHODS, and there is try block added to check if method param is provided, otherwise returns 404.