### PR TITLE
Add djangorestframework 3.9.x to tox

### DIFF
--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,7 +1,7 @@
 djangorestframework-jwt==1.11.0
 django-environ==0.4.5
 django-cors-headers==2.4.0
-djoser==1.2.1
+djoser>=1.2.1
 djangorestframework_simplejwt==3.3.0
 
 pytest==4.1.0

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,7 +1,7 @@
 djangorestframework-jwt==1.11.0
 django-environ==0.4.5
 django-cors-headers==2.4.0
-djoser>=1.2.1
+djoser==1.6.0
 djangorestframework_simplejwt==3.3.0
 
 pytest==4.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,15 @@ envlist =
     isort
     py{34,35,36}-django111-drf{37,38}
     py{34,35,36,37}-django20-drf38
-    py{35,36,37}-django21-drf[38,39]
+    py{35,36,37}-django21-drf{38,39}
+    py{35,36,37}-django22-drf{38,39}
 
 [travis:env]
 DJANGO =
     1.11: django111
     2.0: django20
     2.1: django21
+    2.2: django22
 
 [coverage:run]
 omit =
@@ -68,6 +70,7 @@ basepython =
     py37: python3.7
 deps =
     django111: django>=1.11,<2.0
+    django22: django>=2.2,<2.3
     django21: django>=2.1,<2.2
     django20: django>=2.0,<2.1
     drf37: djangorestframework>=3.7,<3.8

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     isort
     py{34,35,36}-django111-drf{37,38}
     py{34,35,36,37}-django20-drf38
-    py{35,36,37}-django21-drf38
+    py{35,36,37}-django21-drf[38,39]
 
 [travis:env]
 DJANGO =
@@ -72,6 +72,7 @@ deps =
     django20: django>=2.0,<2.1
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
+    drf39: djangorestframework>=3.9,<3.10
     -r{toxinidir}/testproject/requirements/common.txt
 setenv =
     PYTHONPATH = {toxinidir}/testproject


### PR DESCRIPTION
- Added djangorestframework 3.9.x to tox.
- Djoser 1.2.1 is no longer available. I change it to >=1.2.1.