### PR TITLE
remove self._action call, as its not always available

### DIFF
--- a/trench/views/authtoken.py
+++ b/trench/views/authtoken.py
@@ -1,19 +1,28 @@
-from djoser.views import TokenCreateView, TokenDestroyView
 from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
+from rest_framework import status
+from djoser.views import TokenCreateView, TokenDestroyView
+from djoser import utils
+from djoser.conf import settings
 
 from trench.views.base import MFACodeLoginMixin, MFACredentialsLoginMixin
 
 
 class ObtainAuthTokenMixin:
     def handle_user_login(self, serializer, *args, **kwargs):
-        return self._action(serializer)
+        token = utils.login_user(self.request, serializer.user)
+        token_serializer_class = settings.SERIALIZERS.token
+        return Response(
+            data=token_serializer_class(token).data,
+            status=status.HTTP_200_OK,
+        )
 
 
 class AuthTokenLoginOrRequestMFACode(MFACredentialsLoginMixin,
                                      ObtainAuthTokenMixin,
-                                     TokenCreateView,
                                      GenericAPIView):
     pass
+
 
 
 class AuthTokenLoginWithMFACode(MFACodeLoginMixin,

--- a/trench/views/authtoken.py
+++ b/trench/views/authtoken.py
@@ -1,7 +1,7 @@
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework import status
-from djoser.views import TokenCreateView, TokenDestroyView
+from djoser.views import TokenDestroyView
 from djoser import utils
 from djoser.conf import settings
 
@@ -22,7 +22,6 @@ class AuthTokenLoginOrRequestMFACode(MFACredentialsLoginMixin,
                                      ObtainAuthTokenMixin,
                                      GenericAPIView):
     pass
-
 
 
 class AuthTokenLoginWithMFACode(MFACodeLoginMixin,

--- a/trench/views/authtoken.py
+++ b/trench/views/authtoken.py
@@ -1,21 +1,12 @@
+from djoser.views import TokenCreateView, TokenDestroyView
 from rest_framework.generics import GenericAPIView
-from rest_framework.response import Response
-from rest_framework import status
-from djoser.views import TokenDestroyView
-from djoser import utils
-from djoser.conf import settings
 
 from trench.views.base import MFACodeLoginMixin, MFACredentialsLoginMixin
 
 
-class ObtainAuthTokenMixin:
+class ObtainAuthTokenMixin(TokenCreateView):
     def handle_user_login(self, serializer, *args, **kwargs):
-        token = utils.login_user(self.request, serializer.user)
-        token_serializer_class = settings.SERIALIZERS.token
-        return Response(
-            data=token_serializer_class(token).data,
-            status=status.HTTP_200_OK,
-        )
+        return self._action(serializer)
 
 
 class AuthTokenLoginOrRequestMFACode(MFACredentialsLoginMixin,


### PR DESCRIPTION
I can see that just calling `self._action(serializer)` is much more elegant - but `_action` is not available in the `AuthTokenLoginWithMFACode` class...so it always throws an exception, when trying to verify a code.