### PR TITLE
Removed six.text_type

### DIFF
--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -5,9 +5,10 @@ djoser==1.6.0
 djangorestframework_simplejwt==3.3.0
 django-rest-swagger==2.2.0
 
-pytest==5.3.1
-pytest-cov==2.8.1
-pytest-django==3.7.0
+pytest==4.1.0
+pytest-cov==2.6.1
+pytest-django==3.4.5
+attrs==17.4.0
 coverage==4.5.2
 
 isort

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -5,9 +5,9 @@ djoser==1.6.0
 djangorestframework_simplejwt==3.3.0
 django-rest-swagger==2.2.0
 
-pytest==4.1.0
-pytest-cov==2.6.1
-pytest-django==3.4.5
+pytest==5.3.1
+pytest-cov==2.8.1
+pytest-django==3.7.0
 coverage==4.5.2
 
 isort

--- a/trench/views/simplejwt.py
+++ b/trench/views/simplejwt.py
@@ -1,5 +1,3 @@
-from django.utils.six import text_type
-
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -12,8 +10,8 @@ class ObtainJSONWebTokenMixin:
         token = RefreshToken.for_user(serializer.user)
         return Response(
             {
-                'refresh': text_type(token),
-                'access': text_type(token.access_token)
+                'refresh': token,
+                'access': token.access_token
             }
         )
 

--- a/trench/views/simplejwt.py
+++ b/trench/views/simplejwt.py
@@ -10,8 +10,8 @@ class ObtainJSONWebTokenMixin:
         token = RefreshToken.for_user(serializer.user)
         return Response(
             {
-                'refresh': token,
-                'access': token.access_token
+                'refresh': str(token),
+                'access': str(token.access_token)
             }
         )
 


### PR DESCRIPTION
Django 3.0 release removed django.utils.six. We do not support Python 2 so we can remove this from our project.

Based on issue: https://github.com/merixstudio/django-trench/issues/64