### PR TITLE
Add support for Django 3.0 and Python 3.8 and remove Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,15 @@ matrix:
       - { python: "3.6", env: TOX_ENV='flake8' }
       - { python: "3.6", env: TOX_ENV='isort' }
 
-      - { python: "3.4", env: DJANGO=111 DRF=37 }
-      - { python: "3.4", env: DJANGO=20 DRF=37 }
-      - { python: "3.4", env: DJANGO=111 DRF=38 }
-      - { python: "3.4", env: DJANGO=20 DRF=38 }
+      - { python: "3.8", env: DJANGO=30 DRF=310, dist: xenial, sudo: true }
 
-      - { python: "3.5", env: DJANGO=111 DRF=37 }
-      - { python: "3.5", env: DJANGO=20 DRF=37 }
-      - { python: "3.5", env: DJANGO=21 DRF=37 }
-      - { python: "3.5", env: DJANGO=111 DRF=38 }
-      - { python: "3.5", env: DJANGO=20 DRF=38 }
-      - { python: "3.5", env: DJANGO=21 DRF=38 }
-      - { python: "3.5", env: DJANGO=21 DRF=39 }
-      - { python: "3.5", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.5", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=20 DRF=37, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=21 DRF=37, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=20 DRF=38, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=21 DRF=38, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=21 DRF=39, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
 
       - { python: "3.6", env: DJANGO=111 DRF=37 }
       - { python: "3.6", env: DJANGO=20 DRF=37 }
@@ -33,13 +28,20 @@ matrix:
       - { python: "3.6", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
       - { python: "3.6", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
 
-      - { python: "3.7", env: DJANGO=20 DRF=37, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=37, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=20 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=39, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
+      - { python: "3.5", env: DJANGO=111 DRF=37 }
+      - { python: "3.5", env: DJANGO=20 DRF=37 }
+      - { python: "3.5", env: DJANGO=21 DRF=37 }
+      - { python: "3.5", env: DJANGO=111 DRF=38 }
+      - { python: "3.5", env: DJANGO=20 DRF=38 }
+      - { python: "3.5", env: DJANGO=21 DRF=38 }
+      - { python: "3.5", env: DJANGO=21 DRF=39 }
+      - { python: "3.5", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
+      - { python: "3.5", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
+
+      - { python: "3.4", env: DJANGO=111 DRF=37 }
+      - { python: "3.4", env: DJANGO=20 DRF=37 }
+      - { python: "3.4", env: DJANGO=111 DRF=38 }
+      - { python: "3.4", env: DJANGO=20 DRF=38 }
 
 install:
   - pip install tox-travis
@@ -47,6 +49,7 @@ install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PY_VER=py35; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PY_VER=py36; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PY_VER=py37; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then export PY_VER=py38; fi"
   - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-django$DJANGO-drf$DRF; fi"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,23 @@ matrix:
       - { python: "3.6", env: TOX_ENV='flake8' }
       - { python: "3.6", env: TOX_ENV='isort' }
 
-      - { python: "3.8", env: DJANGO=30 DRF=310 DJOSER=203, dist: xenial, sudo: true }
-      - { python: "3.8", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.8", env: DJANGO=30 DRF=310, dist: xenial, sudo: true }
+      - { python: "3.8", env: DJANGO=22 DRF=310, dist: xenial, sudo: true }
 
-      - { python: "3.7", env: DJANGO=111 DRF=310 DJOSER=203, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=20 DRF=310 DJOSER=203, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=310 DJOSER=203, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=111 DRF=310, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=20 DRF=310, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=21 DRF=310, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=22 DRF=310, dist: xenial, sudo: true }
 
-      - { python: "3.6", env: DJANGO=111 DRF=310 DJOSER=203 }
-      - { python: "3.6", env: DJANGO=20 DRF=310 DJOSER=203 }
-      - { python: "3.6", env: DJANGO=21 DRF=310 DJOSER=203 }
-      - { python: "3.6", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.6", env: DJANGO=111 DRF=310 }
+      - { python: "3.6", env: DJANGO=20 DRF=310 }
+      - { python: "3.6", env: DJANGO=21 DRF=310 }
+      - { python: "3.6", env: DJANGO=22 DRF=310, dist: xenial, sudo: true }
 
-      - { python: "3.5", env: DJANGO=111 DRF=310 DJOSER=203 }
-      - { python: "3.5", env: DJANGO=20 DRF=310 DJOSER=203 }
-      - { python: "3.5", env: DJANGO=21 DRF=310 DJOSER=203 }
-      - { python: "3.5", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.5", env: DJANGO=111 DRF=310 }
+      - { python: "3.5", env: DJANGO=20 DRF=310 }
+      - { python: "3.5", env: DJANGO=21 DRF=310 }
+      - { python: "3.5", env: DJANGO=22 DRF=310, dist: xenial, sudo: true }
 
 install:
   - pip install tox-travis
@@ -33,7 +33,7 @@ install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PY_VER=py36; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PY_VER=py37; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then export PY_VER=py38; fi"
-  - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-django$DJANGO-drf$DRF-dj$DJOSER; fi"
+  - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-django$DJANGO-drf$DRF; fi"
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,40 +8,23 @@ matrix:
       - { python: "3.6", env: TOX_ENV='flake8' }
       - { python: "3.6", env: TOX_ENV='isort' }
 
-      - { python: "3.8", env: DJANGO=30 DRF=310, dist: xenial, sudo: true }
+      - { python: "3.8", env: DJANGO=30 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.8", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
 
-      - { python: "3.7", env: DJANGO=20 DRF=37, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=37, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=20 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=21 DRF=39, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.7", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=111 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=20 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=21 DRF=310 DJOSER=203, dist: xenial, sudo: true }
+      - { python: "3.7", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
 
-      - { python: "3.6", env: DJANGO=111 DRF=37 }
-      - { python: "3.6", env: DJANGO=20 DRF=37 }
-      - { python: "3.6", env: DJANGO=21 DRF=37 }
-      - { python: "3.6", env: DJANGO=111 DRF=38 }
-      - { python: "3.6", env: DJANGO=20 DRF=38 }
-      - { python: "3.6", env: DJANGO=21 DRF=38 }
-      - { python: "3.6", env: DJANGO=21 DRF=39 }
-      - { python: "3.6", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.6", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
+      - { python: "3.6", env: DJANGO=111 DRF=310 DJOSER=203 }
+      - { python: "3.6", env: DJANGO=20 DRF=310 DJOSER=203 }
+      - { python: "3.6", env: DJANGO=21 DRF=310 DJOSER=203 }
+      - { python: "3.6", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
 
-      - { python: "3.5", env: DJANGO=111 DRF=37 }
-      - { python: "3.5", env: DJANGO=20 DRF=37 }
-      - { python: "3.5", env: DJANGO=21 DRF=37 }
-      - { python: "3.5", env: DJANGO=111 DRF=38 }
-      - { python: "3.5", env: DJANGO=20 DRF=38 }
-      - { python: "3.5", env: DJANGO=21 DRF=38 }
-      - { python: "3.5", env: DJANGO=21 DRF=39 }
-      - { python: "3.5", env: DJANGO=22 DRF=38, dist: xenial, sudo: true }
-      - { python: "3.5", env: DJANGO=22 DRF=39, dist: xenial, sudo: true }
-
-      - { python: "3.4", env: DJANGO=111 DRF=37 }
-      - { python: "3.4", env: DJANGO=20 DRF=37 }
-      - { python: "3.4", env: DJANGO=111 DRF=38 }
-      - { python: "3.4", env: DJANGO=20 DRF=38 }
+      - { python: "3.5", env: DJANGO=111 DRF=310 DJOSER=203 }
+      - { python: "3.5", env: DJANGO=20 DRF=310 DJOSER=203 }
+      - { python: "3.5", env: DJANGO=21 DRF=310 DJOSER=203 }
+      - { python: "3.5", env: DJANGO=22 DRF=310 DJOSER=203, dist: xenial, sudo: true }
 
 install:
   - pip install tox-travis
@@ -50,7 +33,7 @@ install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PY_VER=py36; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PY_VER=py37; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.8' ]]; then export PY_VER=py38; fi"
-  - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-django$DJANGO-drf$DRF; fi"
+  - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-django$DJANGO-drf$DRF-dj$DJOSER; fi"
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 =========
 
 
+0.2.2 (unreleased)
+==================
+
+* Add support for Django 3.0, Python 3.8 and DRF 3.10.
+
+
 0.2.2 (2019-05-21)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-0.2.2 (unreleased)
+0.2.3 (unreleased)
 ==================
 
 * Add support for Django 3.0, Python 3.8 and DRF 3.10.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ==================
 
 * Add support for Django 3.0, Python 3.8 and DRF 3.10.
+* Remove support for Python 3.4
 
 
 0.2.2 (2019-05-21)

--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ Requirements
 Supported versions
 ******************
 
-* Python 3.4, 3.5, 3.6, 3.7
-* Django 1.11, 2.0, 2.1, 2.2
-* Django REST Framework 3.7, 3.8, 3.9
+* Python 3.4, 3.5, 3.6, 3.7, 3.8
+* Django 1.11, 2.0, 2.1, 2.2, 3.0
+* Django REST Framework 3.7, 3.8, 3.9, 3.10
 
 | If you implement Token Based Authentication:
 

--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ Requirements
 Supported versions
 ******************
 
-* Python 3.4, 3.5, 3.6, 3.7, 3.8
+* Python 3.5, 3.6, 3.7, 3.8
 * Django 1.11, 2.0, 2.1, 2.2, 3.0
-* Django REST Framework 3.7, 3.8, 3.9, 3.10
+* Django REST Framework 3.10
 
 | If you implement Token Based Authentication:
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
@@ -34,5 +36,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -2,7 +2,7 @@ djangorestframework-jwt==1.11.0
 django-environ==0.4.5
 django-cors-headers==3.2.0
 djoser==2.0.3
-djangorestframework_simplejwt==4.4.0
+djangorestframework_simplejwt>=4.3.0,<=4.4.0
 django-rest-swagger==2.2.0
 
 pytest==4.1.0

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,8 +1,8 @@
 djangorestframework-jwt==1.11.0
 django-environ==0.4.5
-django-cors-headers>=2.4.0,<=3.2.0
+django-cors-headers==3.2.0
 djoser==2.0.3
-djangorestframework_simplejwt>=3.3.0,<=4.4.0
+djangorestframework_simplejwt==4.4.0
 django-rest-swagger==2.2.0
 
 pytest==4.1.0

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -2,7 +2,7 @@ djangorestframework-jwt==1.11.0
 django-environ==0.4.5
 django-cors-headers>=2.4.0,<=3.2.0
 djoser==1.6.0
-djangorestframework_simplejwt==3.3.0
+djangorestframework_simplejwt>=3.3.0,<=4.4.0
 django-rest-swagger==2.2.0
 
 pytest==4.1.0

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,6 +1,6 @@
 djangorestframework-jwt==1.11.0
 django-environ==0.4.5
-django-cors-headers==2.4.0
+django-cors-headers>=2.4.0,<=3.2.0
 djoser==1.6.0
 djangorestframework_simplejwt==3.3.0
 django-rest-swagger==2.2.0

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,7 +1,7 @@
 djangorestframework-jwt==1.11.0
 django-environ==0.4.5
 django-cors-headers>=2.4.0,<=3.2.0
-djoser>=1.6.0,<=2.0.3
+djoser==2.0.3
 djangorestframework_simplejwt>=3.3.0,<=4.4.0
 django-rest-swagger==2.2.0
 

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,7 +1,7 @@
 djangorestframework-jwt==1.11.0
 django-environ==0.4.5
 django-cors-headers>=2.4.0,<=3.2.0
-djoser==1.6.0
+djoser>=1.6.0,<=2.0.3
 djangorestframework_simplejwt>=3.3.0,<=4.4.0
 django-rest-swagger==2.2.0
 

--- a/testproject/requirements/default.txt
+++ b/testproject/requirements/default.txt
@@ -1,4 +1,4 @@
 -r common.txt
 
-Django==1.11.23
-djangorestframework==3.9.1
+Django==3.0
+djangorestframework==3.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist =
     isort
     py{34,35,36}-django111-drf{37,38}
     py{34,35,36,37}-django20-drf{37,38}
-    py{35,36,37}-django21-drf{37,38,39}
-    py{35,36,37}-django22-drf{38,39}
+    py{35,36,37}-django21-drf{37,38,39,310}
+    py{35,36,37}-django22-drf{38,39,310}
+    py38-django30-drf310
 
 [travis:env]
 DJANGO =
@@ -13,6 +14,7 @@ DJANGO =
     2.0: django20
     2.1: django21
     2.2: django22
+    3.0: django30
 
 [coverage:run]
 omit =
@@ -68,14 +70,17 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 deps =
     django111: django>=1.11,<2.0
     django22: django>=2.2,<2.3
     django21: django>=2.1,<2.2
     django20: django>=2.0,<2.1
+    django30: django>=3.0,<3.1
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
+    drf310: djangorestframework>=3.10,<3.11
     -r{toxinidir}/testproject/requirements/common.txt
 setenv =
     PYTHONPATH = {toxinidir}/testproject

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 envlist =
     flake8
     isort
-    py{35,36}-django111-drf310-dj203
-    py{35,36,37}-django20-drf310-dj203
-    py{35,36,37}-django21-drf310-dj203
-    py{35,36,37,38}-django22-drf310-dj203
-    py38-django30-drf310-dj203
+    py{35,36}-django111-drf310
+    py{35,36,37}-django20-drf310
+    py{35,36,37}-django21-drf310
+    py{35,36,37,38}-django22-drf310
+    py38-django30-drf310
 
 [travis:env]
 DJANGO =
@@ -78,7 +78,6 @@ deps =
     django20: django>=2.0,<2.1
     django30: django>=3.0,<3.1
     drf310: djangorestframework>=3.10,<3.11
-    dj203: djoser>=2.0.3,<2.0.4  # 1.11, 2.2 | 3.5-3.8 | rest 3.9 - 3.10
     -r{toxinidir}/testproject/requirements/common.txt
 setenv =
     PYTHONPATH = {toxinidir}/testproject

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 envlist =
     flake8
     isort
-    py{34,35,36}-django111-drf{37,38}
-    py{34,35,36,37}-django20-drf{37,38}
-    py{35,36,37}-django21-drf{37,38,39,310}
-    py{35,36,37}-django22-drf{38,39,310}
-    py38-django30-drf310
+    py{35,36}-django111-drf310-dj203
+    py{35,36,37}-django20-drf310-dj203
+    py{35,36,37}-django21-drf310-dj203
+    py{35,36,37,38}-django22-drf310-dj203
+    py38-django30-drf310-dj203
 
 [travis:env]
 DJANGO =
@@ -77,10 +77,8 @@ deps =
     django21: django>=2.1,<2.2
     django20: django>=2.0,<2.1
     django30: django>=3.0,<3.1
-    drf37: djangorestframework>=3.7,<3.8
-    drf38: djangorestframework>=3.8,<3.9
-    drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
+    dj203: djoser>=2.0.3,<2.0.4  # 1.11, 2.2 | 3.5-3.8 | rest 3.9 - 3.10
     -r{toxinidir}/testproject/requirements/common.txt
 setenv =
     PYTHONPATH = {toxinidir}/testproject


### PR DESCRIPTION
* Remove support for Python 3.4
* Remove support for old DRF versions - keep 3.10 only
* Introduce support for Django 3.0 and Python 3.8
* Bump Djoser version to 2.0.3

I would like to remove support for Python 3.4 in next release.