### PR TITLE
WIP: Replace django-rest-framework-jwt by drf-jwt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
 0.2.2 (2019-05-21)
 ==================
 
+* Replace ``djangorestframework-jwt`` by fork ``drf-jwt`` (see https://github.com/jpadilla/django-rest-framework-jwt/issues/484)
+
+
+0.2.2 (2019-05-21)
+==================
+
 * Fix missing _action method on Token Based Authentication views
 * Bump up supported djoser version
 * Add DRF 3.9 and Django 2.2 to test environment

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,10 @@ Changelog
 =========
 
 
-0.2.2 (2019-05-21)
+0.2.3 (unreleased)
 ==================
 
-* Replace ``djangorestframework-jwt`` by fork ``drf-jwt`` (see https://github.com/jpadilla/django-rest-framework-jwt/issues/484)
+* Replace ``djangorestframework-jwt`` by fork ``drf-jwt``
 
 
 0.2.2 (2019-05-21)

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Supported versions
 
 | If you are going to use JWT authentication:
 
-* `django-rest-framework-jwt`_ >= 1.11.0
+* `drf-jwt`_ >= 1.13.3
 
 | or
 
@@ -93,5 +93,5 @@ You can also check our live `demo`_.
 .. _demo: https://django-trench.readthedocs.io/en/latest/demo.html
 .. _django-rest-framework: http://www.django-rest-framework.org
 .. _djoser: https://github.com/sunscrapers/djoser
-.. _django-rest-framework-jwt: https://github.com/GetBlimp/django-rest-framework-jwt
+.. _drf-jwt: https://github.com/Styria-Digital/django-rest-framework-jwt
 .. _djangorestframework-simplejwt: https://github.com/davesque/django-rest-framework-simplejwt

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,7 +46,7 @@ Config
         url(r'^auth/', include('trench.urls')), # Base endpoints
         url(r'^auth/', include('djoser.urls')),
         url(r'^auth/', include('trench.urls.djoser')),  # for Token Based Authorization
-        url(r'^auth/', include('trench.urls.jwt')), # for django-rest-framework-jwt
+        url(r'^auth/', include('trench.urls.jwt')), # for drf-jwt
         url(r'^auth/', include('trench.urls.simplejwt')), # for djangorestframework-simplejwt
     ]
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -28,7 +28,7 @@ Supported versions
 
 | If you are going to use JWT authentication:
 
-* `django-rest-framework-jwt`_ >= 1.11.0
+* `drf-jwt`_ >= 1.13.3
 
 | or
 
@@ -81,5 +81,5 @@ You can also check our live `demo`_.
 .. _demo: https://django-trench.readthedocs.io/en/latest/demo.html
 .. _django-rest-framework: http://www.django-rest-framework.org
 .. _djoser: https://github.com/sunscrapers/djoser
-.. _django-rest-framework-jwt: https://github.com/GetBlimp/django-rest-framework-jwt
+.. _drf-jwt: https://github.com/Styria-Digital/django-rest-framework-jwt
 .. _djangorestframework-simplejwt: https://github.com/davesque/django-rest-framework-simplejwt

--- a/testproject/requirements/common.txt
+++ b/testproject/requirements/common.txt
@@ -1,4 +1,4 @@
-djangorestframework-jwt==1.11.0
+drf-jwt==1.13.3
 django-environ==0.4.5
 django-cors-headers==2.4.0
 djoser==1.6.0


### PR DESCRIPTION
https://github.com/jpadilla/django-rest-framework-jwt/issues/484

Base on issue above I would like to replace unmaintained `django-rest-framework-jwt` by his fork `drf-jwt` (https://github.com/Styria-Digital/django-rest-framework-jwt).