### PR TITLE
 Backup Codes management issue #132 

### DIFF
--- a/testproject/tests/test_second_step_authentication.py
+++ b/testproject/tests/test_second_step_authentication.py
@@ -178,6 +178,9 @@ def test_use_backup_code(active_user_with_encrypted_backup_codes):
     )
     assert response_second_step.status_code == HTTP_200_OK
 
+    mfa_method = active_user.mfa_methods.first()
+    assert len(mfa_method.backup_codes) == 7
+
 
 @pytest.mark.django_db
 def test_activation_otp(active_user):

--- a/trench/command/remove_backup_code.py
+++ b/trench/command/remove_backup_code.py
@@ -21,8 +21,13 @@ class RemoveBackupCodeCommand:
         )
         if serialized_codes is None:
             raise MFAMethodDoesNotExistError()
-        codes = self._remove_code_from_set(
-            backup_codes=set(serialized_codes.split(MFAMethod._BACKUP_CODES_DELIMITER)), code=code
+        codes = MFAMethod._BACKUP_CODES_DELIMITER.join(
+            self._remove_code_from_set(
+                backup_codes=set(
+                    serialized_codes.split(MFAMethod._BACKUP_CODES_DELIMITER)
+                ),
+                code=code,
+            )
         )
         self._mfa_model.objects.filter(user_id=user_id, name=method_name).update(
             _backup_codes=codes


### PR DESCRIPTION
Proposition for fixing issue #132  :

 - perform serialization/unserialization when removing backup_codes used

Add a test to unsure that backup_codes were rightly removed by requesting the backup codes on the current mfa_method of the user