### PR TITLE
Fixed 145. Store backup codes as delimited string, not as set

### DIFF
--- a/testproject/tests/test_second_step_authentication.py
+++ b/testproject/tests/test_second_step_authentication.py
@@ -178,6 +178,22 @@ def test_use_backup_code(active_user_with_encrypted_backup_codes):
     )
     assert response_second_step.status_code == HTTP_200_OK
 
+@pytest.mark.django_db
+def test_use_backup_code_repeated(active_user_with_encrypted_backup_codes):
+    client = TrenchAPIClient()
+    active_user, backup_codes = active_user_with_encrypted_backup_codes
+    response_first_step = client._first_factor_request(user=active_user)
+    ephemeral_token = client._extract_ephemeral_token_from_response(
+        response=response_first_step
+    )
+    response_second_step = client._second_factor_request(
+        code=backup_codes.pop(), ephemeral_token=ephemeral_token
+    )
+    response_second_step = client._second_factor_request(
+        code=backup_codes.pop(), ephemeral_token=ephemeral_token
+    )
+    assert response_second_step.status_code == HTTP_200_OK
+
 
 @pytest.mark.django_db
 def test_activation_otp(active_user):

--- a/trench/command/remove_backup_code.py
+++ b/trench/command/remove_backup_code.py
@@ -25,7 +25,7 @@ class RemoveBackupCodeCommand:
             backup_codes=set(serialized_codes.split(MFAMethod._BACKUP_CODES_DELIMITER)), code=code
         )
         self._mfa_model.objects.filter(user_id=user_id, name=method_name).update(
-            _backup_codes=codes
+            _backup_codes=MFAMethod._BACKUP_CODES_DELIMITER.join([*codes])
         )
 
     def _remove_code_from_set(self, backup_codes: Set[str], code: str) -> Set[str]:


### PR DESCRIPTION
Fixes #145 

Backup codes are initially stores as delimited string. On backup code removal the codes where stored as set. Changed the removal code so that it stores the codes as delimited string also.