### PR TITLE
[DR2-99] 2FA cannot be deactivated starting with trench 0.3

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -85,7 +85,11 @@ MFA method activation confirmation
 MFA method deactivation
 ***********************
 
-| Deactivates the specified method. Depeding on :doc: `settings` sends out an authentication code and requires confirmation.
+| Deactivates the specified method. Depending on :doc: `settings` sends out an authentication code and requires confirmation.
+| Note: You can deactivate primary mfa method if it's you one and only mfa method. However, you cannot deactivate mfa
+| method that is primary if there are other activate methods. First you should change primary method to other, then
+| deactivate mfa method of your choice.
+
 
 .. list-table::
     :stub-columns: 1
@@ -348,8 +352,6 @@ Change user's primary MFA method
 ********************************
 
 | Change user's primary authentication method.
-
-| Display methods activated by user
 
 .. list-table::
     :stub-columns: 1

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -86,9 +86,9 @@ MFA method deactivation
 ***********************
 
 | Deactivates the specified method. Depending on :doc: `settings` sends out an authentication code and requires confirmation.
-| Note: You can deactivate primary mfa method if it's you one and only mfa method. However, you cannot deactivate mfa
-| method that is primary if there are other activate methods. First you should change primary method to other, then
-| deactivate mfa method of your choice.
+| Note: You can deactivate a primary  MFA method only if it's the last active method assigned to a user.
+| However, you cannot deactivate a primary MFA method if there are other methods active.
+| You should change primary method to a different one first, and then deactivate the method.
 
 
 .. list-table::

--- a/testproject/tests/conftest.py
+++ b/testproject/tests/conftest.py
@@ -128,6 +128,26 @@ def active_user_with_email_and_inactive_other_methods_otp() -> UserModel:
 
 
 @pytest.fixture()
+def active_user_with_email_and_active_other_methods_otp() -> UserModel:
+    user, created = User.objects.get_or_create(
+        username="imhotep",
+        email="imhotep@pyramids.eg",
+    )
+    if created:
+        user.set_password("secretkey"),
+        user.is_active = True
+        user.save()
+        mfa_method_creator(user=user, method_name="email")
+        mfa_method_creator(
+            user=user, method_name="sms_twilio", is_primary=False
+        )
+        mfa_method_creator(
+            user=user, method_name="app", is_primary=False
+        )
+    return user
+
+
+@pytest.fixture()
 def active_user_with_encrypted_backup_codes() -> Tuple[UserModel, Set[str]]:
     return active_user_with_backup_codes(encrypt_codes=True)
 

--- a/testproject/tests/test_commands.py
+++ b/testproject/tests/test_commands.py
@@ -60,6 +60,7 @@ def test_deactivate_an_only_mfa_method(active_user_with_application_otp):
         mfa_method_name=mfa_method.name,
     )
     mfa_model = get_mfa_model()
-    assert active_user_with_application_otp.mfa_methods.get(name="app").is_active == False
+    mfa_method.refresh_from_db()
+    assert mfa_method.is_active is False
     assert len(mfa_model.objects.list_active(user_id=active_user_with_application_otp.id)) == 0
 

--- a/testproject/tests/test_commands.py
+++ b/testproject/tests/test_commands.py
@@ -50,3 +50,16 @@ def test_deactivate_inactive_mfa(active_user_with_application_otp):
             user_id=active_user_with_application_otp.id,
             mfa_method_name=mfa_method.name,
         )
+
+
+@pytest.mark.django_db
+def test_deactivate_an_only_mfa_method(active_user_with_application_otp):
+    mfa_method = active_user_with_application_otp.mfa_methods.get(name="app")
+    deactivate_mfa_method_command(
+        user_id=active_user_with_application_otp.id,
+        mfa_method_name=mfa_method.name,
+    )
+    mfa_model = get_mfa_model()
+    assert active_user_with_application_otp.mfa_methods.get(name="app").is_active == False
+    assert len(mfa_model.objects.list_active(user_id=active_user_with_application_otp.id)) == 0
+

--- a/testproject/tests/test_commands.py
+++ b/testproject/tests/test_commands.py
@@ -62,5 +62,8 @@ def test_deactivate_an_only_mfa_method(active_user_with_application_otp):
     mfa_model = get_mfa_model()
     mfa_method.refresh_from_db()
     assert mfa_method.is_active is False
-    assert len(mfa_model.objects.list_active(user_id=active_user_with_application_otp.id)) == 0
-
+    assert len(
+        mfa_model.objects.list_active(
+            user_id=active_user_with_application_otp.id
+        )
+    ) == 0

--- a/testproject/tests/test_second_step_authentication.py
+++ b/testproject/tests/test_second_step_authentication.py
@@ -238,12 +238,47 @@ def test_confirm_activation_otp(active_user):
 
 
 @pytest.mark.django_db
-def test_deactivation_of_primary_method(active_user_with_email_otp):
+def test_deactivation_of_an_only_primary_mfa_method(active_user_with_email_otp):
     client = TrenchAPIClient()
     mfa_method = active_user_with_email_otp.mfa_methods.first()
     handler = get_mfa_handler(mfa_method=mfa_method)
     client.authenticate_multi_factor(
         mfa_method=mfa_method, user=active_user_with_email_otp
+    )
+    response = client.post(
+        path="/auth/email/deactivate/",
+        data={"code": handler.create_code()},
+        format="json",
+    )
+    assert response.status_code == HTTP_204_NO_CONTENT
+
+@pytest.mark.django_db
+def test_deactivation_of_an_only_primary_mfa_method_when_other_mfa_inactive(
+    active_user_with_email_and_inactive_other_methods_otp
+):
+    client = TrenchAPIClient()
+    mfa_method = active_user_with_email_and_inactive_other_methods_otp.mfa_methods.first()
+    handler = get_mfa_handler(mfa_method=mfa_method)
+    client.authenticate_multi_factor(
+        mfa_method=mfa_method, user=active_user_with_email_and_inactive_other_methods_otp
+    )
+    response = client.post(
+        path="/auth/email/deactivate/",
+        data={"code": handler.create_code()},
+        format="json",
+    )
+    assert response.status_code == HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_deactivation_of_primary_mfa_method_when_other_active_mfa_methods(
+    active_user_with_email_and_active_other_methods_otp
+):
+    client = TrenchAPIClient()
+    mfa_method = active_user_with_email_and_active_other_methods_otp.mfa_methods.first()
+    handler = get_mfa_handler(mfa_method=mfa_method)
+    client.authenticate_multi_factor(
+        mfa_method=mfa_method, user=active_user_with_email_and_active_other_methods_otp
     )
     response = client.post(
         path="/auth/email/deactivate/",

--- a/testproject/tests/test_second_step_authentication.py
+++ b/testproject/tests/test_second_step_authentication.py
@@ -252,15 +252,20 @@ def test_deactivation_of_an_only_primary_mfa_method(active_user_with_email_otp):
     )
     assert response.status_code == HTTP_204_NO_CONTENT
 
+
 @pytest.mark.django_db
 def test_deactivation_of_an_only_primary_mfa_method_when_other_mfa_inactive(
     active_user_with_email_and_inactive_other_methods_otp
 ):
     client = TrenchAPIClient()
-    mfa_method = active_user_with_email_and_inactive_other_methods_otp.mfa_methods.first()
+    mfa_method = (
+        active_user_with_email_and_inactive_other_methods_otp.mfa_methods
+        .first()
+    )
     handler = get_mfa_handler(mfa_method=mfa_method)
     client.authenticate_multi_factor(
-        mfa_method=mfa_method, user=active_user_with_email_and_inactive_other_methods_otp
+        mfa_method=mfa_method,
+        user=active_user_with_email_and_inactive_other_methods_otp
     )
     response = client.post(
         path="/auth/email/deactivate/",

--- a/trench/backends/base.py
+++ b/trench/backends/base.py
@@ -76,7 +76,10 @@ class AbstractMessageDispatcher(ABC):
         return self._get_otp().verify(otp=code)
 
     def _get_otp(self) -> TOTP:
-        return create_otp_command(secret=self._mfa_method.secret, interval=self._get_valid_window())
+        return create_otp_command(
+            secret=self._mfa_method.secret,
+            interval=self._get_valid_window()
+        )
 
     def _get_valid_window(self) -> int:
         return self._config.get(

--- a/trench/command/deactivate_mfa_method.py
+++ b/trench/command/deactivate_mfa_method.py
@@ -14,7 +14,9 @@ class DeactivateMFAMethodCommand:
     @atomic
     def execute(self, mfa_method_name: str, user_id: int) -> None:
         mfa = self._mfa_model.objects.get_by_name(user_id=user_id, name=mfa_method_name)
-        number_of_active_mfa_methods = self._mfa_model.objects.filter(user_id=user_id, is_active=True).count()
+        number_of_active_mfa_methods = self._mfa_model.objects.filter(
+            user_id=user_id, is_active=True
+        ).count()
         if mfa.is_primary and number_of_active_mfa_methods > 1:
             raise DeactivationOfPrimaryMFAMethodError()
         if not mfa.is_active:

--- a/trench/command/deactivate_mfa_method.py
+++ b/trench/command/deactivate_mfa_method.py
@@ -14,7 +14,8 @@ class DeactivateMFAMethodCommand:
     @atomic
     def execute(self, mfa_method_name: str, user_id: int) -> None:
         mfa = self._mfa_model.objects.get_by_name(user_id=user_id, name=mfa_method_name)
-        if mfa.is_primary:
+        active_mfa_methods = self._mfa_model.objects.list_active(user_id=user_id)
+        if mfa.is_primary and len(active_mfa_methods) > 1:
             raise DeactivationOfPrimaryMFAMethodError()
         if not mfa.is_active:
             raise MFANotEnabledError()

--- a/trench/command/deactivate_mfa_method.py
+++ b/trench/command/deactivate_mfa_method.py
@@ -14,8 +14,8 @@ class DeactivateMFAMethodCommand:
     @atomic
     def execute(self, mfa_method_name: str, user_id: int) -> None:
         mfa = self._mfa_model.objects.get_by_name(user_id=user_id, name=mfa_method_name)
-        active_mfa_methods = self._mfa_model.objects.list_active(user_id=user_id)
-        if mfa.is_primary and len(active_mfa_methods) > 1:
+        number_of_active_mfa_methods = self._mfa_model.objects.filter(user_id=user_id, is_active=True).count()
+        if mfa.is_primary and number_of_active_mfa_methods > 1:
             raise DeactivationOfPrimaryMFAMethodError()
         if not mfa.is_active:
             raise MFANotEnabledError()


### PR DESCRIPTION
What was done:
- make deactivation of one and only active, primary mfa method as possible
- add constraint that deactivation of primary mfa method when there are other active methods is not possible
- update docs
- update tests